### PR TITLE
Fix rainbow parentheses

### DIFF
--- a/lua/plugins/editing.lua
+++ b/lua/plugins/editing.lua
@@ -17,33 +17,37 @@ return {
 
   -- nvim-treesitter：基于 Tree-sitter 的语法解析器
   -- 提供更加精准的高亮与代码折叠功能
-{
-  "nvim-treesitter/nvim-treesitter",
-  build = ":TSUpdate",
-  event = { "BufReadPost", "BufNewFile" },
-  config = function()
-    require("nvim-treesitter.configs").setup({
-      ensure_installed = {
-        "lua", "vim", "bash", "python", "javascript",
-        "typescript", "html", "css", "json", "markdown",
-        "c", "cpp", "go", "rust", "toml", "yaml"
-      },
-      highlight = {
-        enable = true,
-        additional_vim_regex_highlighting = false,
-        -- Rainbow parentheses
+  {
+    "nvim-treesitter/nvim-treesitter",
+    build = ":TSUpdate",
+    event = { "BufReadPost", "BufNewFile" },
+    dependencies = {
+      -- 彩虹括号支持
+      "p00f/nvim-ts-rainbow",
+    },
+    config = function()
+      require("nvim-treesitter.configs").setup({
+        ensure_installed = {
+          "lua", "vim", "bash", "python", "javascript",
+          "typescript", "html", "css", "json", "markdown",
+          "c", "cpp", "go", "rust", "toml", "yaml",
+        },
+        highlight = {
+          enable = true,
+          additional_vim_regex_highlighting = false,
+        },
+        -- 彩虹括号
         rainbow = {
           enable = true,
           extended_mode = true,
           max_file_lines = nil,
-        }
-      },
-      indent = {
-        enable = true,
-      },
-    })
-  end,
-},
+        },
+        indent = {
+          enable = true,
+        },
+      })
+    end,
+  },
 {
   "akinsho/toggleterm.nvim",
   version = "*",


### PR DESCRIPTION
## Summary
- add `p00f/nvim-ts-rainbow` dependency
- move rainbow config to top level so it loads correctly

## Testing
- `nvim --headless -c 'luafile lua/plugins/editing.lua' +'q'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688111370188832092476d502b68bc90