### PR TITLE
Fix which-key warnings

### DIFF
--- a/lua/plugins/ui.lua
+++ b/lua/plugins/ui.lua
@@ -127,20 +127,14 @@ return {
       -- ⬇️ 直接在这里注册按键
       local wk = require("which-key")
       wk.register({
-        ["<leader>f"] = {
-          name = "查找 🔍",
-          f = { "<cmd>Telescope find_files<CR>", "查找文件" },
-          g = { "<cmd>Telescope live_grep<CR>", "全局搜索" },
-        },
-        ["<leader>t"] = {
-          name = "终端 🖥️",
-          f = { "<cmd>ToggleTerm direction=float<CR>", "浮动终端" },
-        },
-        ["<leader>q"] = {
-          name = "窗口 ❌",
-          q = { "<cmd>close<CR>", "关闭窗口" },
-          Q = { "<cmd>qa!<CR>", "强制退出" },
-        },
+        { "<leader>f", group = "查找 🔍" },
+        { "<leader>ff", "<cmd>Telescope find_files<CR>", desc = "查找文件" },
+        { "<leader>fg", "<cmd>Telescope live_grep<CR>", desc = "全局搜索" },
+        { "<leader>t", group = "终端 🖥️" },
+        { "<leader>tf", "<cmd>ToggleTerm direction=float<CR>", desc = "浮动终端" },
+        { "<leader>q", group = "窗口 ❌" },
+        { "<leader>qq", "<cmd>close<CR>", desc = "关闭窗口" },
+        { "<leader>qQ", "<cmd>qa!<CR>", desc = "强制退出" },
       })
     end,
   },


### PR DESCRIPTION
## Summary
- update mappings for which-key plugin to new spec

## Testing
- `NVIM_APPNAME=$(pwd) nvim --headless "+lua print('test')" +qa`

------
https://chatgpt.com/codex/tasks/task_e_68847103c108832094454d08e9b375d6