### PR TITLE
Organize quicknote keymaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,21 @@
 - `i`：进入当前目录为根
 - `u`：回到上级目录
 
+### Quicknote
+
+- `<leader>qn`：新建当前行笔记
+- `<leader>qN`：新建并打开项目笔记
+- `<leader>qo`：打开当前行笔记
+- `<leader>qj`：跳转到下一条笔记
+- `<leader>qk`：跳转到上一条笔记
+- `<leader>ql`：列出所有笔记
+- `<leader>qs`：显示笔记标记
+- `<leader>qS`：隐藏笔记标记
+- `<leader>qd`：删除当前行笔记
+- `<leader>qD`：删除项目笔记
+- `<leader>qi`：导入项目笔记
+- `<leader>qe`：导出项目笔记
+
 ### 自动补全
 
 - `<Tab>`：确认当前建议或跳转到下一个片段

--- a/lua/core/keymaps/quicknote.lua
+++ b/lua/core/keymaps/quicknote.lua
@@ -1,0 +1,36 @@
+local M = {}
+
+function M.setup()
+  local map = vim.keymap.set
+  local opts = { noremap = true, silent = true }
+  local fn = require("quicknote")
+  local prefix = "<leader>q"
+
+  local function nmap(lhs, rhs, desc)
+    map("n", prefix .. lhs, rhs, vim.tbl_extend("force", opts, { desc = desc }))
+  end
+
+  -- A. 新建 / 打开
+  nmap("n", fn.NewNoteAtCurrentLine, "新建当前行笔记")
+  nmap("N", fn.NewNoteAtCWD, "新建并打开项目笔记")
+  nmap("o", fn.OpenNoteAtCurrentLine, "打开当前行笔记")
+
+  -- B. 浏览 / 跳转
+  nmap("j", fn.JumpToNextNote, "跳转到下一条笔记")
+  nmap("k", fn.JumpToPreviousNote, "跳转到上一条笔记")
+  nmap("l", "<cmd>Telescope quicknote<CR>", "Telescope 列出笔记")
+
+  -- C. 标记显示开关
+  nmap("s", fn.ShowNoteSigns, "显示笔记标记")
+  nmap("S", fn.HideNoteSigns, "隐藏笔记标记")
+
+  -- D. 删除 / 清理
+  nmap("d", fn.DeleteNoteAtCurrentLine, "删除当前行笔记")
+  nmap("D", fn.DeleteNoteAtCWD, "删除项目笔记")
+
+  -- E. 导入 / 导出
+  nmap("i", fn.ImportNotesForCWD, "导入项目笔记")
+  nmap("e", fn.ExportNotesForCWD, "导出项目笔记")
+end
+
+return M

--- a/lua/plugins/editing/quicknote.lua
+++ b/lua/plugins/editing/quicknote.lua
@@ -4,52 +4,17 @@ return {
     dependencies = { "nvim-lua/plenary.nvim" },
     config = function()
       ----------------------------------------
-      -- 1. 初始化
+      -- 初始化
       ----------------------------------------
       require("quicknote").setup({
         sign = "󰓝", -- 可换成你喜欢的 Nerd Font 图标
         -- mode = "portable" 是默认
       })
 
-      ----------------------------------------
-      -- 2. 快捷键映射
-      ----------------------------------------
-      local map    = vim.keymap.set
-      local opts   = { noremap = true, silent = true }
-      local fn     = require("quicknote")
-      local prefix = "<leader>q"
-
-      -- 小工具：自动组合 opts + desc
-      local function nmap(lhs, rhs, desc)
-        map("n", lhs, rhs, vim.tbl_extend("force", opts, { desc = desc }))
-      end
-
-
-      -- A. 新建 / 打开
-      nmap(prefix.."n", fn.NewNoteAtCurrentLine,   "新建当前行笔记")
-      nmap(prefix.."N", fn.NewNoteAtCWD,    "新建并打开项目笔记")
-
-      nmap(prefix.."o", fn.OpenNoteAtCurrentLine,  "打开当前行笔记")
-
-      -- B. 浏览 / 跳转
-      nmap(prefix.."j", fn.JumpToNextNote,         "跳转到下一条笔记")
-      nmap(prefix.."k", fn.JumpToPreviousNote,     "跳转到上一条笔记")
-      nmap(prefix.."l", "<cmd>Telescope quicknote<CR>", "Telescope 列出笔记")
-
-      -- C. 标记显示开关
-      nmap(prefix.."s", fn.ShowNoteSigns,          "显示笔记标记")
-      nmap(prefix.."S", fn.HideNoteSigns,          "隐藏笔记标记")
-
-      -- D. 删除 / 清理
-      nmap(prefix.."d", fn.DeleteNoteAtCurrentLine,"删除当前行笔记")
-      nmap(prefix.."D", fn.DeleteNoteAtCWD,        "删除项目笔记")
-
-      -- E. 导入 / 导出
-      nmap(prefix.."i", fn.ImportNotesForCWD,      "导入项目笔记")
-      nmap(prefix.."e", fn.ExportNotesForCWD,      "导出项目笔记")
+      require("core.keymaps.quicknote").setup()
 
       ----------------------------------------
-      -- 3. Telescope 扩展
+      -- Telescope 扩展
       ----------------------------------------
       pcall(require("telescope").load_extension, "quicknote")
     end,


### PR DESCRIPTION
## Summary
- move quicknote.nvim mappings into `core.keymaps`
- update the plugin to use the new keymaps module
- document the new shortcuts in README

## Testing
- `find lua -name '*.lua' -print0 | xargs -0 luac -p`

------
https://chatgpt.com/codex/tasks/task_e_6886e0ed05f483209fff6371061e7a9c