### PR TITLE
Move plugin keymaps into keymaps modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,13 @@
 - `i`：进入当前目录为根
 - `u`：回到上级目录
 
+### Git
+
+- `<leader>gd`：打开 Diffview
+- `<leader>gD`：关闭 Diffview
+- `<leader>gh`：查看文件历史
+- `<leader>gH`：关闭文件历史
+
 ### Quicknote
 
 - `<leader>qn`：新建当前行笔记

--- a/lua/core/keymaps/conform.lua
+++ b/lua/core/keymaps/conform.lua
@@ -1,0 +1,13 @@
+local M = {}
+
+M.keys = {
+    {
+        "<leader>cf",
+        function()
+            require("conform").format({ lsp_fallback = true })
+        end,
+        desc = "Format buffer",
+    },
+}
+
+return M

--- a/lua/core/keymaps/diffview.lua
+++ b/lua/core/keymaps/diffview.lua
@@ -1,0 +1,10 @@
+local M = {}
+
+M.keys = {
+    { "<leader>gd", "<cmd>DiffviewOpen<CR>", desc = "Git Diff View" },
+    { "<leader>gD", "<cmd>DiffviewClose<CR>", desc = "Close Diff View" },
+    { "<leader>gh", "<cmd>DiffviewFileHistory<CR>", desc = "Git File History" },
+    { "<leader>gH", "<cmd>DiffviewClose<CR>", desc = "Close File History" },
+}
+
+return M

--- a/lua/core/keymaps/general.lua
+++ b/lua/core/keymaps/general.lua
@@ -1,32 +1,38 @@
 local M = {}
 
 function M.setup()
-	vim.g.mapleader = " "
+    vim.g.mapleader = " "
 
-	-- 文件树开关
-	vim.keymap.set("n", "<leader>e", ":NvimTreeToggle<CR>", { desc = "切换文件树" })
+    local function map(mode, lhs, rhs, desc)
+        vim.keymap.set(mode, lhs, rhs, { noremap = true, silent = true, desc = desc })
+    end
 
-	-- 缓冲区管理
-	vim.keymap.set("n", "<leader>bd", "<cmd>bdelete<CR>", { desc = "关闭当前 buffer" })
+    -- 文件树开关
+    map("n", "<leader>e", "<cmd>NvimTreeToggle<CR>", "切换文件树")
 
-	-- 使用 <leader>y 将选中文本复制到系统剪贴板
-	vim.keymap.set({ "n", "v" }, "<leader>y", '"+y', { desc = "复制到系统剪贴板" })
+    -- 缓冲区管理
+    map("n", "<leader>bd", "<cmd>bdelete<CR>", "关闭当前 buffer")
 
-	-- 使用 <leader>p 从系统剪贴板粘贴
-	vim.keymap.set({ "n", "v" }, "<leader>p", '"+p', { desc = "粘贴系统剪贴板" })
-	-- Normal 和 Visual 模式：H 跳行首（^），L 跳行尾（$）
-	vim.keymap.set({ "n", "v" }, "H", "^", { desc = "Jump to line start (non-blank)" })
-	vim.keymap.set({ "n", "v" }, "L", "$", { desc = "Jump to line end" })
-	local map = vim.keymap.set
-	local opts = { noremap = true, silent = true }
-	-- 关闭当前窗口 / 强制关闭
-	map("n", "<leader>wd", "<cmd>close<CR>", vim.tbl_extend("force", opts, { desc = "关闭当前窗口" }))
-	map("n", "<leader>wD", "<cmd>close!<CR>", vim.tbl_extend("force", opts, { desc = "强制关闭窗口" }))
-	-- 只保留当前窗口
-	map("n", "<leader>wo", "<cmd>only<CR>", vim.tbl_extend("force", opts, { desc = "关闭其他窗口" }))
-	-- 退出 Neovim（写出 \ 保存）
-	map("n", "<leader>wq", "<cmd>q<CR>", vim.tbl_extend("force", opts, { desc = "退出 Neovim" }))
-	map("n", "<leader>wQ", "<cmd>qa!<CR>", vim.tbl_extend("force", opts, { desc = "强制退出全部" }))
+    -- 使用 <leader>y 将选中文本复制到系统剪贴板
+    map({ "n", "v" }, "<leader>y", '"+y', "复制到系统剪贴板")
+
+    -- 使用 <leader>p 从系统剪贴板粘贴
+    map({ "n", "v" }, "<leader>p", '"+p', "粘贴系统剪贴板")
+
+    -- Normal 和 Visual 模式：H 跳行首（^），L 跳行尾（$）
+    map({ "n", "v" }, "H", "^", "Jump to line start (non-blank)")
+    map({ "n", "v" }, "L", "$", "Jump to line end")
+
+    -- 关闭当前窗口 / 强制关闭
+    map("n", "<leader>wd", "<cmd>close<CR>", "关闭当前窗口")
+    map("n", "<leader>wD", "<cmd>close!<CR>", "强制关闭窗口")
+
+    -- 只保留当前窗口
+    map("n", "<leader>wo", "<cmd>only<CR>", "关闭其他窗口")
+
+    -- 退出 Neovim（写出 \ 保存）
+    map("n", "<leader>wq", "<cmd>q<CR>", "退出 Neovim")
+    map("n", "<leader>wQ", "<cmd>qa!<CR>", "强制退出全部")
 end
 
 return M

--- a/lua/plugins/dev/conform.lua
+++ b/lua/plugins/dev/conform.lua
@@ -55,14 +55,6 @@ return {
 		}
 	end,
 
-	-- 3. 手动触发
-	keys = {
-		{
-			"<leader>cf",
-			function()
-				require("conform").format({ lsp_fallback = true })
-			end,
-			desc = "Format buffer",
-		},
-	},
+        -- 3. 手动触发
+        keys = require("core.keymaps.conform").keys,
 }

--- a/lua/plugins/git/diffview.lua
+++ b/lua/plugins/git/diffview.lua
@@ -6,12 +6,7 @@ return {
 		"DiffviewToggleFiles",
 		"DiffviewFileHistory",
 	},
-	dependencies = { "nvim-lua/plenary.nvim" },
-	keys = {
-		{ "<leader>gd", "<cmd>DiffviewOpen<CR>", desc = "Git Diff View" },
-		{ "<leader>gD", "<cmd>DiffviewClose<CR>", desc = "Close Diff View" },
-		{ "<leader>gh", "<cmd>DiffviewFileHistory<CR>", desc = "Git File History" },
-		{ "<leader>gH", "<cmd>DiffviewClose<CR>", desc = "Close File History" },
-	},
-	config = true,
+        dependencies = { "nvim-lua/plenary.nvim" },
+        keys = require("core.keymaps.diffview").keys,
+        config = true,
 }


### PR DESCRIPTION
## Summary
- move Diffview key mappings into a dedicated keymap module
- move Conform format keymap to its own module
- reference the new keymap modules from plugin specs
- document git Diffview shortcuts in README
- refactor keymap general module to use unified mapping helper

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68878bf8005483208db225d314f22cc1